### PR TITLE
Allow unsafe values in form with overrides

### DIFF
--- a/src/HTMLForm/Form.php
+++ b/src/HTMLForm/Form.php
@@ -112,12 +112,15 @@ class Form implements \ArrayAccess
         $this->elements = [];
         if (!empty($elements)) {
             foreach ($elements as $key => $element) {
+                $overrides = $element['overrides'] ?? [];
+                unset($element['overrides']);
                 $this->elements[$key] = FormElementFactory::create($key, $element);
                 $this->elements[$key]->setDefault([
                     "wrapper-element" => $this->form["wrapper-element"],
                     "br-after-label"  => $this->form["br-after-label"],
                     "escape-values"   => $this->form["escape-values"],
                 ]);
+                $this->elements[$key]->setDefault($overrides);
             }
         }
 

--- a/src/HTMLForm/FormElement.php
+++ b/src/HTMLForm/FormElement.php
@@ -229,7 +229,9 @@ abstract class FormElement implements \ArrayAccess
             : null;
 
         $text = isset($this['text'])
-            ? htmlentities($this['text'], ENT_QUOTES, $this->characterEncoding)
+            ? $this->default["escape-values"]
+                ? htmlentities($this['text'], ENT_QUOTES, $this->characterEncoding)
+                : $this['text']
             : null;
 
         $checked = isset($this['checked']) && $this['checked']
@@ -257,7 +259,9 @@ abstract class FormElement implements \ArrayAccess
             : null;
 
         $onlyValue = isset($this['value'])
-            ? htmlentities($this['value'], ENT_QUOTES, $this->characterEncoding)
+            ? $this->default["escape-values"]
+                ? htmlentities($this['value'], ENT_QUOTES, $this->characterEncoding)
+                : $this['value']
             : null;
 
         $value = isset($this['value'])

--- a/test/HTMLForm/FormElementTest.php
+++ b/test/HTMLForm/FormElementTest.php
@@ -74,4 +74,20 @@ class FormElementTestTest extends TestCase
         $res = $element->validate(['email']);
         $this->assertTrue($res, "Validation email fails.");
     }
+
+    public function testUnsafeValues()
+    {
+        $element = new FormElementTest('test');
+
+        $element->setDefault([
+            "escape-values" => true
+        ]);
+        $element->attributes["value"] = "anax&me";
+        $this->assertEquals(" value='anax&amp;me'", $element->getHTMLDetails()['value']);
+        $element->setDefault([
+            "escape-values" => false
+        ]);
+        $element->attributes["value"] = "anax&me";
+        $this->assertEquals(" value='anax&me'", $element->getHTMLDetails()['value']);
+    }
 }


### PR DESCRIPTION
Right now there is no way of having a value not go through `htmlentities`. This causes a problem when the values are already escaped manually.

This PR adds the ability to have unescaped values in the form fields and the ability to override form values at individual element level.

```php
$form->create(
    [
        // ...
    ],
    [
        "field" => [
            "type" => "text",
            "overrides" => [
                "escape-values" => false
            ],
    ]
)
```